### PR TITLE
Bump aiobookoo to 0.1.1 (flow rate fix)

### DIFF
--- a/custom_components/bookoo/manifest.json
+++ b/custom_components/bookoo/manifest.json
@@ -22,6 +22,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["aiobookoo"],
-  "requirements": ["aiobookoo==0.1.0"],
-  "version": "1.0.0"
+  "requirements": ["aiobookoo==0.1.1"],
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Updates the `aiobookoo` dependency to **0.1.1**, which fixes flow rate decoding (2-byte big-endian instead of low byte only — flow ≥ 2.56 g/s previously wrapped, e.g. 3.00 g/s → 0.44 g/s). See makerwolf/aiobookoo#1.

- `requirements`: `aiobookoo==0.1.0` → `aiobookoo==0.1.1`
- integration `version`: `1.0.0` → `1.0.1` (so HACS surfaces the update to users)

aiobookoo 0.1.1 is published on PyPI.